### PR TITLE
feat: update Dependabot configuration for new requirements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# Code Owners for slack-github-threads
+# This file defines who will be automatically requested for review when changes are made to specific files.
+# For more information, see: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global owners - will be requested for review on all PRs
+* @markhallen
+
+# Dependency updates (Dependabot PRs)
+Gemfile @markhallen
+Gemfile.lock @markhallen
+Dockerfile @markhallen
+.github/workflows/ @markhallen
+
+# Configuration files
+config/ @markhallen
+.kamal/ @markhallen
+
+# Documentation
+README.md @markhallen
+docs/ @markhallen
+CONTRIBUTING.md @markhallen
+SECURITY.md @markhallen

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,6 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 5
-    reviewers:
-      - "your-username" # Replace with actual GitHub username
-    assignees:
-      - "your-username" # Replace with actual GitHub username
     commit-message:
       prefix: "deps"
       prefix-development: "deps-dev"
@@ -39,10 +35,6 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 3
-    reviewers:
-      - "your-username" # Replace with actual GitHub username
-    assignees:
-      - "your-username" # Replace with actual GitHub username
     commit-message:
       prefix: "ci"
       include: "scope"
@@ -58,10 +50,6 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 3
-    reviewers:
-      - "your-username" # Replace with actual GitHub username
-    assignees:
-      - "your-username" # Replace with actual GitHub username
     commit-message:
       prefix: "docker"
       include: "scope"


### PR DESCRIPTION
- Remove deprecated 'reviewers' and 'assignees' fields from dependabot.yml
- Add CODEOWNERS file to handle reviewer assignments for Dependabot PRs
- Configure code ownership for dependencies, configuration, and documentation
- Aligns with GitHub's new requirement to use CODEOWNERS instead of reviewers field

This addresses the deprecation warning about the reviewers field being removed
and ensures proper reviewer assignment for dependency update PRs.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring/code cleanup

## Testing

- [ ] Tests pass locally
- [ ] New tests added for new functionality
- [ ] Manual testing completed

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Add any additional notes or context about the PR here.
