### PR TITLE
feat: simplify release workflow by removing PR creation step

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -110,13 +110,13 @@ jobs:
       run: |
         VERSION_TAG="v${{ steps.next_version.outputs.NEXT_VERSION }}"
         echo "📤 Pushing changes and tag $VERSION_TAG to GitHub..."
-
+        
         # Push any changelog changes
         git push origin main
-
+        
         # Push the version tag (this will trigger the release.yml workflow)
         git push origin "$VERSION_TAG"
-
+        
         echo "✅ Successfully pushed tag $VERSION_TAG"
         echo "🎯 The release.yml workflow will now create the GitHub release automatically"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  pull_request:
-    types: [closed]
-    branches: [main]
 
 env:
   VERSION_REGEX: 'v[0-9]+\.[0-9]+\.[0-9]+'
@@ -17,12 +14,6 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # Only run if it's a merged PR with release label, or a version tag push
-    if: |
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.merged == true &&
-       contains(github.event.pull_request.labels.*.name, 'release'))
 
     steps:
     - name: Checkout code
@@ -42,30 +33,13 @@ jobs:
         bundle exec rake rubocop
         bundle exec rake test
 
-    - name: Extract version from tag or PR
+    - name: Extract version from tag
       id: version
       run: |
-        if [ "${{ github.event_name }}" = "push" ]; then
-          # Extract from tag
-          VERSION=${GITHUB_REF#refs/tags/v}
-        else
-          # Extract from PR title (should be "Release vX.Y.Z")
-          VERSION=$(echo "${{ github.event.pull_request.title }}" | grep -oE "$VERSION_REGEX" | sed 's/^v//')
-          if [ -z "$VERSION" ]; then
-            echo "Could not extract version from PR title: ${{ github.event.pull_request.title }}"
-            exit 1
-          fi
-        fi
+        # Extract version from tag (refs/tags/v1.2.3 -> 1.2.3)
+        VERSION=${GITHUB_REF#refs/tags/v}
         echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
         echo "Extracted version: $VERSION"
-
-    - name: Create tag if from PR
-      if: github.event_name == 'pull_request'
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git tag -a "v${{ steps.version.outputs.VERSION }}" -m "Release version ${{ steps.version.outputs.VERSION }}"
-        git push origin "v${{ steps.version.outputs.VERSION }}"
 
     - name: Extract changelog for version
       id: changelog

--- a/README.md
+++ b/README.md
@@ -297,13 +297,13 @@ This project supports multiple release workflows: automated GitHub Actions, smar
 
 Create releases directly from GitHub's web interface:
 
-1. **Go to Actions tab** → **"Create Release PR"** workflow
+1. **Go to Actions tab** → **"Create Release"** workflow
 2. **Click "Run workflow"** and choose:
    - `auto` - Let the system analyze commits and suggest release type
    - `major/minor/patch` - Specify release type manually
    - `dry_run` - Preview what would be released
-3. **Review and merge** the created PR
-4. **Release is automatically published** when PR merges
+3. **The release is created immediately** - no PR needed!
+4. **GitHub release is automatically published** with changelog
 
 ### 🧠 Smart Local Release Process
 


### PR DESCRIPTION
- Rename create-release-pr.yml to create-release.yml
- Remove all PR creation and github-script dependencies
- Implement direct tag creation and push for immediate releases
- Simplify release.yml to only handle tag pushes (remove PR triggers)
- Update README to reflect streamlined "Create Release" workflow

This eliminates GitHub Actions permission issues with PR creation
and provides a faster, more direct release process. The workflow
now creates releases immediately without requiring PR review.

Fixes permission error: "GitHub Actions is not permitted to create
or approve pull requests"

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring/code cleanup

## Testing

- [ ] Tests pass locally
- [ ] New tests added for new functionality
- [ ] Manual testing completed

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Add any additional notes or context about the PR here.
