### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/markhallen/slack-github-threads/security/code-scanning/1](https://github.com/markhallen/slack-github-threads/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` block in the workflow file. The strictest approach is to set the default at the workflow level, which applies to all jobs unless overridden. Since this workflow only checks out code and runs tests/audits, the jobs likely only require `contents: read` permission. This addresses the CodeQL warning, protects against accidental elevation to write permissions if repository/org settings change, and is future-proof.

The fix involves adding a `permissions:` block with `contents: read` below the `name` line, and before the `on:` block, in `.github/workflows/ci.yml`. Since both jobs (test and security) do not appear to need any `write` access, workflow-level `contents: read` is appropriate. If a job ever requires more privileges later, it can override via its own job-level `permissions`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
